### PR TITLE
UnderlineColor, FloatingLabelAlpha, TextColor

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -36,6 +36,7 @@
     <attr format="color" name="met_textColorHint"/>
     <attr format="boolean" name="met_validateOnFocusLost"/>
     <attr format="boolean" name="met_checkCharactersCountAtBeginning"/>
+    <attr format="float" name="met_floatingLabelAlpha"/>
 
   </declare-styleable>
 </resources>


### PR DESCRIPTION
added focused colorstate for textcolor
floatinglabelalpha defines the alpha value of the floatinglabel when not selected (0.26 is default)
underlinecolor uses 0 as not set indicator (primarycolor is used in focused state, other states use basecolor with alpha 0x44 for disabled and 0xDF for normal)